### PR TITLE
second validator fires but does not wait

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -104,7 +104,7 @@
                             success: function() {
                                 validFunc(element, attrs[successMessage], validator, scope, ctrl);
                                 if (leftValidation.length) {
-                                    checkValidation(scope, element, attrs, ctrl, leftValidation, value);
+                                    return checkValidation(scope, element, attrs, ctrl, leftValidation, value);
                                 } else {
                                     return true;
                                 }


### PR DESCRIPTION
If more than one ng-validator exists on element the second validator is invoked recursively, the recursive calls does not wait to complete and the first one just returns control to the promise.
